### PR TITLE
fix: reestructurar indice de herramientas como categoria (RC2)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,9 @@ PR: [#28](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/28) - @c
 - **Cumplimiento de Requisitos:** Inclusión explícita de la lógica para el **RF3 (Notificaciones)** y validación de flujos de llegada en `Sala de Espera`.
 - **Consistencia del Modelo:** Definición de la clase `Usuario` como **abstracta** para garantizar la integridad y coherencia del diseño orientado a objetos.
 
+### Fixed
+- [fix/rc2-indice-herramientas] Reestructurar índice de herramientas como categoría. PR: [#36](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/36) - @carolabenvenuto-uces (Diseñador de Tarjetas CRC)
+
 ## [Release Actividad Obligatoria N°1] - 2026-03-29
 ### Added
 - [feature/analista-...] Análisis de requerimientos: RFs, RNFs y NotebookLM.

--- a/herramientas-agile/herramientas_agile.md
+++ b/herramientas-agile/herramientas_agile.md
@@ -1,25 +1,3 @@
-# Índice de Herramientas Agile - Diseño de Clases (A2)
+# Herramientas Agile
 
-Este apartado contiene la documentación técnica detallada del sistema de gestión de turnos médicos. Se ha utilizado la técnica de **Tarjetas CRC** (Clase-Responsabilidad-Colaborador) para definir una arquitectura robusta, escalable y desacoplada, organizada en 8 componentes clave.
-
----
-
-## 📂 Tarjetas CRC (Arquitectura de 8 Clases)
-
-Haga clic en cada enlace para ver el detalle técnico de la clase:
-
-1.  **[01 - Usuario (Abstracta)](./tarjetas-crc/01-tarjeta-crc-usuario.md)**: Clase base que centraliza la autenticación y los datos comunes de todos los actores del sistema.
-2.  **[02 - Paciente](./tarjetas-crc/02-tarjeta-crc-paciente.md)**: Actor principal que solicita y gestiona activamente sus turnos y cancelaciones.
-3.  **[03 - Secretaria](./tarjetas-crc/03-tarjeta-crc-secretaria.md)**: Ejecutora operativa encargada de la logística de turnos, gestión de departamentos y visualización de agendas.
-4.  **[04 - Doctor](./tarjetas-crc/04-tarjeta-crc-doctor.md)**: Profesional médico que gestiona su disponibilidad y registra los diagnósticos de las consultas atendidas.
-5.  **[05 - Turno](./tarjetas-crc/05-tarjeta-crc-turno.md)**: Entidad núcleo que vincula paciente y profesional, proveyendo los detalles y estados de cada cita.
-6.  **[06 - Agenda](./tarjetas-crc/06-tarjeta-crc-agenda.md)**: Administradora de las reglas de disponibilidad, bloqueos y franjas horarias de los profesionales.
-7.  **[07 - Sala de Espera](./tarjetas-crc/07-tarjeta-crc-sala-espera.md)**: Gestiona la recepción activa y el flujo dinámico de pacientes en orden FIFO (cola de espera).
-8.  **[08 - Sistema (Orquestador)](./tarjetas-crc/08-tarjeta-crc-sistema.md)**: Motor central que gestiona las colecciones globales, la autenticación y el envío de notificaciones automáticas (RF3).
-
----
-
-## 📝 Notas de Diseño Final
-* **Especialización:** Se separaron las responsabilidades de Doctor, Secretaria y Paciente para cumplir con el principio de Responsabilidad Única (SOLID).
-* **Desacoplamiento:** El Sistema delega la persistencia y notificaciones a servicios especializados, evitando el antipatrón de "Objeto Todopoderoso".
-* **Consistencia Técnica:** Todas las responsabilidades han sido redactadas en formato activo para reflejar el comportamiento dinámico de los objetos en cumplimiento con los Requerimientos Funcionales (RF1-RF5).
+- [Tarjetas CRC](tarjetas-crc/)


### PR DESCRIPTION
### 🛠️ Fix - Reestructuración de índice de herramientas (RC2)

**Descripción:**
Se corrigió la estructura del archivo de índice de herramientas para que funcione como una categoría de nivel superior, eliminando el listado individual de archivos según lo solicitado en el feedback docente (RC2). El objetivo es normalizar la navegación jerárquica del repositorio.

**Cambios realizados:**
* Se eliminó el listado de los 8 archivos individuales de tarjetas CRC que generaban narrativa excesiva.
* Se configuró el acceso directo a la carpeta `./tarjetas-crc/` para centralizar el acceso al diseño.
* Se simplificó el contenido para cumplir con el estándar técnico requerido por la cátedra.

**Archivo modificado:**
* `herramientas-agile/herramientas_agile.md`

**Responsable:**
@carolabenvenuto-uces (Diseñador de Tarjetas CRC)