### PR TITLE
fix/changelog-md-a2 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,23 +1,18 @@
 # Changelog
 
-## [Unreleased]
+## [Release Actividad Obligatoria N°2] - 2026-04-16
 ### Added
-- [feature/documentador-coordinador-a2] Documentacion y coordinacion del repositorio para la AO2: code reviews asistidos con Copilot Agent Mode (PR #26, #31 y #28), documentacion de prompts/ajustes en `ia/a2/documentador-coordinador.md` y actualizacion del README/changelog.
-  PR: [#30](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/30) - @FacundoGuiraldes (Documentador y Coordinador de Repositorio)
-- [feature/espec-escenarios-casos-uso-add-escenario-1] Especialista en 5 escenarios de casos de uso. 
-PR: [#28](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/28) - @caterinacerdan (Especialista en Escenarios de Casos de Uso)
-- [feature/diseniador-tarjetas-crc...] Diseño y organización de Tarjetas CRC: 
-  - Estructura final de **8 clases** detalladas con diseño orientado a objetos.
-  - Creación de carpeta `herramientas-agile/tarjetas-crc/` con archivos individuales.
-  - Índice general en `herramientas_agile.md` con enlaces funcionales.
-  - Documentación detallada del proceso de refinamiento de IA en `ia/a2/`.
-  PR: [#26](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/26) - @carolabenvenuto-uces (Diseñador de Tarjetas CRC)
+- [feature/documentador-coordinador-a2] Documentación y coordinación del repositorio para AO2. PR: [#30](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/30) - @FacundoGuiraldes (Documentador y Coordinador de Repositorio)
+- [feature/espec-escenarios-casos-uso-add-escenario-1] Especialista en 5 escenarios de casos de uso. PR: [#28](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/28) - @caterinacerdan (Especialista en Escenarios de Casos de Uso)
+- [feature/modelador-diag-casos-uso-crear-diagramas-v2] Modelador de 5 diagramas de casos de uso en PlantUML. PR: [#31](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/31) - @ValeriaMSilva (Modelador de Diagramas de Casos de Uso)
+- [feature/diseniador-tarjetas-crc-add-tarjeta-clase-1-v2] Diseño y organización de 8 Tarjetas CRC. PR: [#26](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/26) - @carolabenvenuto-uces (Diseñador de Tarjetas CRC)
 
 ### Modified
-- **Refactorización técnica integral:** Se ajustaron las responsabilidades a formato activo y se sincronizaron los atributos (como `departamento` en Secretaria y colecciones en `Sistema`) con el boceto inicial de Excalidraw.
-- **Optimización de Arquitectura:** Mejora en el desacoplamiento de la clase Sistema y aplicación de principios **SOLID** (Responsabilidad Única) en la jerarquía de `Usuario`.
-- **Cumplimiento de Requisitos:** Inclusión explícita de la lógica para el **RF3 (Notificaciones)** y validación de flujos de llegada en `Sala de Espera`.
-- **Consistencia del Modelo:** Definición de la clase `Usuario` como **abstracta** para garantizar la integridad y coherencia del diseño orientado a objetos.
+- [feature/documentador-coordinador-a2] Refactorización técnica integral del modelo: responsabilidades en formato activo, sincronización de atributos y principios SOLID. PR: [#30](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/30) - @FacundoGuiraldes (Documentador y Coordinador)
+- [feature/diseniador-tarjetas-crc-add-tarjeta-clase-1-v2] Inclusión explícita de lógica RF3 (Notificaciones) y definición de Usuario como abstracta. PR: [#26](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/26) - @carolabenvenuto-uces (Diseñador de Tarjetas CRC)
+
+### Fixed
+- [fix/changelog-md-a2] Corrección de estructura del changelog según release. PR: [#33](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/33) - @FacundoGuiraldes (Documentador y Coordinador)
 
 ## [Release Actividad Obligatoria N°1] - 2026-03-29
 ### Added
@@ -41,5 +36,3 @@ PR: [#17](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/17) - @c
 - [fix/templates-pr] Correción de rutas y templates de feature y realease. PR: [#20](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/20) - @caterinacerdan (Modelador de casos de uso)
 - [fix] Reubicación de introduccion.md en anexos y eliminación de duplicado.
 Commit: [55fc7ce](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/commit/55fc7ce2f6b20820bacb90f7f1f97f91bda00aab) - @caterinacerdan (Modelador de casos de uso)
-- [fix] Corrección de estructura del changelog según release.
-Commit: [4c2fe83](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/commit/4c2fe832221b125bccc1b2577b382999d0fe0041) - @caterinacerdan (Modelador de casos de uso)

--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,8 @@
 - [feature/diseniador-tarjetas-crc-add-tarjeta-clase-1-v2] Inclusión explícita de lógica RF3 (Notificaciones) y definición de Usuario como abstracta. PR: [#26](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/26) - @carolabenvenuto-uces (Diseñador de Tarjetas CRC)
 
 ### Fixed
-- [fix/changelog-md-a2] Corrección de estructura del changelog según release. PR: [#33](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/33) - @FacundoGuiraldes (Documentador y Coordinador)
+- [fix/changelog-md-a2] Corrección de estructura del changelog según release. PR: [#37](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/37) - @FacundoGuiraldes (Documentador y Coordinador)
+- [fix/fix/adición-PR31-changelog.md] Corrección de estructura del changelog PR: [#33](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/33) - @caterinacerdan (Modelador de casos de uso)
 
 ## [Release Actividad Obligatoria N°1] - 2026-03-29
 ### Added


### PR DESCRIPTION
[fix/changelog-md-a2] Corrección de estructura del changelog según rúbrica A2

**Cambios:**
- Cambiar `[Unreleased]` a `## [Release Actividad Obligatoria N°2] - 2026-04-16`
- Convertir entradas a formato de una línea: `[feature/rama] Descripción. PR: [#N](link) - @usuario (Rol)`
- Agregar sección `### Fixed` con rama y PR link
- Mover corrección de estructura del changelog de A1 a A2 (PR #33)

**Referencias:**
- Comentario de rúbrica: https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/34#discussion_r3107980748