### PR TITLE
fix: corrijo formato de una sola linea y reubico PR 31 en la release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 - [feature/diseniador-tarjetas-crc-add-tarjeta-clase-1-v2] Inclusión explícita de lógica RF3 (Notificaciones) y definición de Usuario como abstracta. PR: [#26](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/26) - @carolabenvenuto-uces (Diseñador de Tarjetas CRC)
 
 ### Fixed
+- [fix/formato-changelog-pr31] Corrección de salto de línea y reubicación de PR 31 en changelog. PR: [#31]https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/31 - @ValeriaMSilva (Modelador de Diagramas de Casos de Uso)
 - [fix/changelog-md-a2] Corrección de estructura del changelog según release. PR: [#37](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/37) - @FacundoGuiraldes (Documentador y Coordinador)
 - [fix/fix/adición-PR31-changelog.md] Corrección de estructura del changelog PR: [#33](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/33) - @caterinacerdan (Especialista en Escenarios de Casos de Uso)
 - [fix/rc2-indice-herramientas] Reestructurar índice de herramientas como categoría. PR: [#36](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/36) - @carolabenvenuto-uces (Diseñador de Tarjetas CRC)


### PR DESCRIPTION
 🛠️ Fix - Corrección de formato y ubicación de PR #31 en changelog.md

Descripción: Se realizó el ajuste de formato solicitado en el feedback técnico (Code Review) sobre el archivo changelog.md para cumplir estrictamente con las reglas de registro del repositorio y la trazabilidad de la Release N°2.

Cambios realizados:
Corrección de formato (PR #31): Se eliminó el salto de línea erróneo en el registro de la PR #31 (Modelado de 5 diagramas de casos de uso), unificando todo el texto en un solo renglón como exige el estándar del repositorio.

Reubicación de Release: Se trasladó dicho registro desde la sección general [Unreleased] hacia la sección oficial [Release Actividad Obligatoria N°2] bajo la categoría ### Added.

Registro del Fix actual: Se agregó la entrada correspondiente a esta nueva rama de corrección bajo la categoría ### Fixed.

Archivos modificados:
changelog.md
Responsable: @ValeriaMSilva (Modelador de Diagramas de Casos de Uso)