### PR TITLE
Fix/RC_9_Especialista_OCP-LSP

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - [feature/documentador-coordinador-repo-update-readme.md] Documentación y coordinación del repositorio. PR: [#64](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/64) - @caterinacerdan (Documentador y Coordinador de Repositorio) | Issue: [#63](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/issues/63)
 
 ### Fixed
+- [Fix/RC_9_Esp_OCP-LSP] fix: cambiar prompts de OCP y LSP a bloques de código triple-backtick (RC 9). PR: [#70](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/70) - @FacundoGuiraldes (Especialista en Principios de Extensión - OCP + LSP)
 - [fix/correcciones-documentador] Correcciones de formato, estructura y redacción en la documentación del repositorio. PR: [#67](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/67) - @caterinacerdan (Documentador y Coordinador de Repositorio + SRP)
 - [fix/rc8-formato-prompt-isp] fix: cambiar blockquote a bloque de código triple-backtick en prompt de IA (RC 8). PR: [#66](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/66) - @ValeriaMSilva (Especialista en Segregación de Interfaces - ISP)
 

--- a/ia/primer-parcial/especialista-lsp.md
+++ b/ia/primer-parcial/especialista-lsp.md
@@ -1,6 +1,9 @@
 # Auditoría de IA - Especialista en LSP
 
-* **Prompt utilizado:** "Analiza las jerarquías de herencia propuestas para el Sistema de Turnos Médicos y verifica si se cumple el Principio de Sustitución de Liskov (LSP) para la clase Doctor. Propón una jerarquía simple y coherente con el dominio, indicando por qué una subclase puede sustituir a su superclase sin alterar el comportamiento esperado."
+* **Prompt utilizado:**
+```text
+Analiza las jerarquías de herencia propuestas para el Sistema de Turnos Médicos y verifica si se cumple el Principio de Sustitución de Liskov (LSP) para la clase Doctor. Propón una jerarquía simple y coherente con el dominio, indicando por qué una subclase puede sustituir a su superclase sin alterar el comportamiento esperado.
+```
 * **Archivos de contexto:** `anexos/introduccion.md`, `diagramas/01-diagrama-clases/01-boceto-inicial.excalidraw`, `herramientas-agile/tarjetas-crc/04-tarjeta-crc-doctor.md`, `herramientas-agile/tarjetas-crc/06-tarjeta-crc-agenda.md`, `herramientas-agile/tarjetas-crc/05-tarjeta-crc-turno.md`.
 * **Output obtenido:** Propuesta de una jerarquía con `Doctor` como clase abstracta y especialidades concretas (`Cardiologo`, `Pediatra` y `Traumatologo`), acompañada por una explicación sobre contrato de comportamiento, uso polimórfico de `verAgenda(): void` y condiciones para que las especialidades médicas puedan reutilizar la misma interfaz pública sin romper clientes existentes.
 * **Ajustes críticos realizados:** Se alineó la documentación con el diagrama final agregando más de un subtipo concreto y explicitando el contrato esperado de `verAgenda(): void`. También se corrigió la descripción del resultado para eliminar referencias a Strategy que pertenecen al análisis de OCP y reforzar que el contexto usado incluye introducción, boceto inicial y tarjetas CRC relevantes.

--- a/ia/primer-parcial/especialista-lsp.md
+++ b/ia/primer-parcial/especialista-lsp.md
@@ -1,9 +1,24 @@
-# Auditoría de IA - Especialista en LSP
+# Documentación de Uso de IA - Especialista LSP
 
-* **Prompt utilizado:**
-```text
+## 🤖 Herramienta Utilizada
+**[Cursor - Agent Mode]**
+
+## 💬 Prompt Utilizado
+
+```
 Analiza las jerarquías de herencia propuestas para el Sistema de Turnos Médicos y verifica si se cumple el Principio de Sustitución de Liskov (LSP) para la clase Doctor. Propón una jerarquía simple y coherente con el dominio, indicando por qué una subclase puede sustituir a su superclase sin alterar el comportamiento esperado.
 ```
-* **Archivos de contexto:** `anexos/introduccion.md`, `diagramas/01-diagrama-clases/01-boceto-inicial.excalidraw`, `herramientas-agile/tarjetas-crc/04-tarjeta-crc-doctor.md`, `herramientas-agile/tarjetas-crc/06-tarjeta-crc-agenda.md`, `herramientas-agile/tarjetas-crc/05-tarjeta-crc-turno.md`.
-* **Output obtenido:** Propuesta de una jerarquía con `Doctor` como clase abstracta y especialidades concretas (`Cardiologo`, `Pediatra` y `Traumatologo`), acompañada por una explicación sobre contrato de comportamiento, uso polimórfico de `verAgenda(): void` y condiciones para que las especialidades médicas puedan reutilizar la misma interfaz pública sin romper clientes existentes.
-* **Ajustes críticos realizados:** Se alineó la documentación con el diagrama final agregando más de un subtipo concreto y explicitando el contrato esperado de `verAgenda(): void`. También se corrigió la descripción del resultado para eliminar referencias a Strategy que pertenecen al análisis de OCP y reforzar que el contexto usado incluye introducción, boceto inicial y tarjetas CRC relevantes.
+
+## 📂 Archivos de contexto referenciados
+* `anexos/introduccion.md`
+* `diagramas/01-diagrama-clases/01-boceto-inicial.excalidraw`
+* `herramientas-agile/tarjetas-crc/04-tarjeta-crc-doctor.md`
+* `herramientas-agile/tarjetas-crc/06-tarjeta-crc-agenda.md`
+* `herramientas-agile/tarjetas-crc/05-tarjeta-crc-turno.md`
+
+## 📤 Output obtenido (Fragmento representativo)
+La IA propuso una jerarquía con `Doctor` como clase abstracta y especialidades concretas (`Cardiologo`, `Pediatra` y `Traumatologo`), acompañada por una explicación sobre contrato de comportamiento, uso polimórfico de `verAgenda(): void` y condiciones para que las especialidades médicas puedan reutilizar la misma interfaz pública sin romper clientes existentes.
+
+## 🛠️ Ajustes realizados
+1. **Alineación con el diagrama final:** Se agregó más de un subtipo concreto y se explicitó el contrato esperado de `verAgenda(): void` para que la documentación refleje fielmente la jerarquía propuesta.
+2. **Corrección del output obtenido:** Se eliminaron referencias al patrón Strategy, que pertenecen al análisis de OCP, y se reforzó que el contexto utilizado incluye la introducción, el boceto inicial y las tarjetas CRC relevantes.

--- a/ia/primer-parcial/especialista-ocp.md
+++ b/ia/primer-parcial/especialista-ocp.md
@@ -1,9 +1,25 @@
-# Auditoría de IA - Especialista en OCP
+# Documentación de Uso de IA - Especialista OCP
 
-* **Prompt utilizado:**
-```text
+## 🤖 Herramienta Utilizada
+**[Cursor - Agent Mode]**
+
+## 💬 Prompt Utilizado
+
+```
 Actúa como especialista en arquitectura de software. Identifica dos clases del Sistema de Turnos Médicos que violen el principio OCP y propón una refactorización usando el patrón Strategy.
 ```
-* **Archivos de contexto:** `anexos/introduccion.md`, `diagramas/01-diagrama-clases/01-boceto-inicial.excalidraw`, `herramientas-agile/tarjetas-crc/04-tarjeta-crc-doctor.md`, `herramientas-agile/tarjetas-crc/06-tarjeta-crc-agenda.md`, `herramientas-agile/tarjetas-crc/05-tarjeta-crc-turno.md`.
-* **Output obtenido:** Propuesta de refactorización con una interfaz `EstrategiaDisponibilidad`, estrategias concretas para distintos contextos médicos y una reorganización de `Doctor` y `Agenda` para delegar la definición y validación de disponibilidad sin modificar sus responsabilidades principales.
-* **Ajustes críticos realizados:** Se descartaron abstracciones genéricas que no aportaban al dominio y se aterrizó la solución a clases reales del sistema (`Doctor`, `Agenda` y `Turno`) identificadas en el boceto y las CRC. Se reforzó la justificación para demostrar que OCP impacta sobre dos clases principales: `Doctor`, que delega el cálculo de disponibilidad, y `Agenda`, que valida turnos contra una estrategia extensible. Tras una revisión técnica, se corrigió una ambigüedad en el diagrama UML para explicitar que `Agenda` también posee una referencia a la estrategia, permitiendo que la validación sea independiente del tipo de recurso médico.
+
+## 📂 Archivos de contexto referenciados
+* `anexos/introduccion.md`
+* `diagramas/01-diagrama-clases/01-boceto-inicial.excalidraw`
+* `herramientas-agile/tarjetas-crc/04-tarjeta-crc-doctor.md`
+* `herramientas-agile/tarjetas-crc/06-tarjeta-crc-agenda.md`
+* `herramientas-agile/tarjetas-crc/05-tarjeta-crc-turno.md`
+
+## 📤 Output obtenido (Fragmento representativo)
+La IA propuso una refactorización con una interfaz `EstrategiaDisponibilidad`, estrategias concretas para distintos contextos médicos y una reorganización de `Doctor` y `Agenda` para delegar la definición y validación de disponibilidad sin modificar sus responsabilidades principales.
+
+## 🛠️ Ajustes realizados
+1. **Focalización en clases del dominio:** Se descartaron abstracciones genéricas que no aportaban al dominio y se aterrizó la solución a clases reales del sistema (`Doctor`, `Agenda` y `Turno`) identificadas en el boceto y las tarjetas CRC.
+2. **Refuerzo de la justificación OCP:** Se explicitó que el principio impacta sobre dos clases principales: `Doctor`, que delega el cálculo de disponibilidad, y `Agenda`, que valida turnos contra una estrategia extensible.
+3. **Corrección del diagrama UML:** Tras una revisión técnica, se corrigió una ambigüedad para explicitar que `Agenda` también posee una referencia a la estrategia, permitiendo que la validación sea independiente del tipo de recurso médico.

--- a/ia/primer-parcial/especialista-ocp.md
+++ b/ia/primer-parcial/especialista-ocp.md
@@ -1,6 +1,9 @@
 # Auditoría de IA - Especialista en OCP
 
-* **Prompt utilizado:** "Actúa como especialista en arquitectura de software. Identifica dos clases del Sistema de Turnos Médicos que violen el principio OCP y propón una refactorización usando el patrón Strategy."
+* **Prompt utilizado:**
+```text
+Actúa como especialista en arquitectura de software. Identifica dos clases del Sistema de Turnos Médicos que violen el principio OCP y propón una refactorización usando el patrón Strategy.
+```
 * **Archivos de contexto:** `anexos/introduccion.md`, `diagramas/01-diagrama-clases/01-boceto-inicial.excalidraw`, `herramientas-agile/tarjetas-crc/04-tarjeta-crc-doctor.md`, `herramientas-agile/tarjetas-crc/06-tarjeta-crc-agenda.md`, `herramientas-agile/tarjetas-crc/05-tarjeta-crc-turno.md`.
 * **Output obtenido:** Propuesta de refactorización con una interfaz `EstrategiaDisponibilidad`, estrategias concretas para distintos contextos médicos y una reorganización de `Doctor` y `Agenda` para delegar la definición y validación de disponibilidad sin modificar sus responsabilidades principales.
 * **Ajustes críticos realizados:** Se descartaron abstracciones genéricas que no aportaban al dominio y se aterrizó la solución a clases reales del sistema (`Doctor`, `Agenda` y `Turno`) identificadas en el boceto y las CRC. Se reforzó la justificación para demostrar que OCP impacta sobre dos clases principales: `Doctor`, que delega el cálculo de disponibilidad, y `Agenda`, que valida turnos contra una estrategia extensible. Tras una revisión técnica, se corrigió una ambigüedad en el diagrama UML para explicitar que `Agenda` también posee una referencia a la estrategia, permitiendo que la validación sea independiente del tipo de recurso médico.


### PR DESCRIPTION
🛠️ Fix - RC 9: Corrección de formato de prompt en documentación IA (OCP + LSP)

📝 **Descripción:**
Esta Pull Request resuelve el Request Change 9 (RC 9) indicado por el docente sobre la evidencia de uso de IA para el rol de Especialista en Principios de Extensión (OCP + LSP) correspondiente al Primer Parcial.

✅ **Cambios realizados:**
🤖 **Documentación IA:** Se actualizaron los archivos `ia/primer-parcial/especialista-ocp.md` y `ia/primer-parcial/especialista-lsp.md` incluyendo:
- Eliminación del formato de lista simple en la sección del prompt utilizado.
- Reemplazo por un bloque de código literal de triple tilde invertida especificando el lenguaje `text`, cumpliendo estrictamente con el formato Markdown requerido por la cátedra.

📋 **Changelog:** Se añadió el registro correspondiente en el archivo `changelog.md` bajo la sección `### Fixed` del Primer Parcial.

📂 **Archivos modificados:**
- `ia/primer-parcial/especialista-ocp.md`
- `ia/primer-parcial/especialista-lsp.md`
- `changelog.md`

👤 **Responsable:**
@FacundoGuiraldes (Especialista en Principios de Extensión - OCP + LSP)