### PR TITLE
fix/esp-actividades-3-4-5-doc-ia

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 - [feature/doc-coord-repo-update-readme-md] Actualización de la tabla de integrantes con los nuevos roles asignados para la Actividad N3. - @carolabenvenuto-uces (Documentador y Coordinador)
 - [fix/correccion-indices-readme-coordinador] Corrección de formato del índice de diagramas de actividades, reestructuración del `README.md` para asegurar coherencia conceptual del modelo dinámico y actualización de `diagramas/diagramasUML.md` con la complementariedad de modelos. PR: [#95](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/95) - @carolabenvenuto-uces (Documentador y Coordinador) 
 - [fix/correccion-puml-caso-de-uso] correccion de la sintaxis de puml y restauración de actividad 2 caso de uso. PR: [#97](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/97) - @caterinacerdan (Especialista en diagramas de actividades caso de uso 1 y 2)
+- [fix/esp-actividades-3-4-5-doc-ia] Corrección de cierres de flujo en diagramas de actividades (un único `stop`; `END` en alternativos) y actualización de documentación IA. PR: [#98](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/98) - @FacundoGuiraldes (Especialista en Diagramas de Actividades)
 
 ## [Release Primer Parcial] - 2026-04-25
 ### Added

--- a/diagramas/02-casos-de-uso/diagramas_de_casos_de_uso.md
+++ b/diagramas/02-casos-de-uso/diagramas_de_casos_de_uso.md
@@ -1,7 +1,7 @@
 # Diagramas de Casos de Uso
 
 - [Caso de Uso 1 - Solicitar turno](02-caso-uso-solicitar-turno-01/02-caso-uso-solicitar-turno-01.puml)
-- [Caso de Uso 2 - Cancelar turno](02-caso-uso-cancelar-turno-02/02-caso-uso-cancelar-turno-02.puml)
+<!-- Caso de Uso 2 - Cancelar turno: archivo eliminado en PR #87 -->
 - [Caso de Uso 3 - Registrar llegada del paciente](02-caso-uso-registrar-llegada-03/02-caso-uso-registrar-llegada-03.puml)
 - [Caso de Uso 4 - Registrar al paciente](02-caso-uso-registrar-paciente-04/02-caso-uso-registrar-paciente-04.puml)
 - [Caso de Uso 5 - Ver agenda](02-caso-uso-ver-agenda-05/02-caso-uso-ver-agenda-05.puml)

--- a/diagramas/04-diagramas-actividades/04-actividad-registrar-llegada-03.puml
+++ b/diagramas/04-diagramas-actividades/04-actividad-registrar-llegada-03.puml
@@ -42,7 +42,7 @@ else (No encontrado)
     paciente sin turno
     (RF5 / RNF4)
   end note
-  stop
+  END
 endif
 
 |Secretaria|

--- a/diagramas/04-diagramas-actividades/04-actividad-registrar-paciente-04.puml
+++ b/diagramas/04-diagramas-actividades/04-actividad-registrar-paciente-04.puml
@@ -44,7 +44,7 @@ if (¿El paciente ya existe\nen la base de datos?) then (Sí - DNI duplicado)
     paciente preexistente,
     no se genera duplicado
   end note
-  stop
+  END
 else (No - DNI nuevo)
   :Continúa con la\nvalidación de datos;
 endif

--- a/diagramas/04-diagramas-actividades/04-actividad-solicitar-turno-01.puml
+++ b/diagramas/04-diagramas-actividades/04-actividad-solicitar-turno-01.puml
@@ -46,15 +46,17 @@ if (¿El paciente existe en el sistema?) then (sí)
   |Paciente|
   :Recibir confirmación\nde la solicitud exitosa;
 
-  stop
+  END
 
 else (no)
 
   |Secretaria|
   :Informar al paciente que no está registrado;
 
-  stop
+  END
 
 endif
+
+stop
 
 @enduml

--- a/diagramas/04-diagramas-actividades/04-actividad-ver-agenda-05.puml
+++ b/diagramas/04-diagramas-actividades/04-actividad-ver-agenda-05.puml
@@ -33,7 +33,7 @@ else (No - credenciales inválidas)
     Caso alternativo:
     error de autenticación
   end note
-  stop
+  END
 endif
 
 |Doctor|

--- a/diagramas/04-diagramas-actividades/04-actividad-ver-agenda-05.puml
+++ b/diagramas/04-diagramas-actividades/04-actividad-ver-agenda-05.puml
@@ -63,7 +63,7 @@ else (No - agenda vacía)
     agenda sin turnos
     (RF2 / RF4)
   end note
-  stop
+  END
 endif
 
 |Sistema|

--- a/diagramas/04-diagramas-actividades/diagramas_de_actividades.md
+++ b/diagramas/04-diagramas-actividades/diagramas_de_actividades.md
@@ -7,3 +7,5 @@
 | Registrar Llegada del Paciente | [04-actividad-registrar-llegada-03.puml](./04-actividad-registrar-llegada-03.puml) | [04-actividad-registrar-llegada-03.png](./04-actividad-registrar-llegada-03.png) |
 | Registrar Paciente | [04-actividad-registrar-paciente-04.puml](./04-actividad-registrar-paciente-04.puml) | [04-actividad-registrar-paciente-04.png](./04-actividad-registrar-paciente-04.png) |
 | Ver Agenda | [04-actividad-ver-agenda-05.puml](./04-actividad-ver-agenda-05.puml) | [04-actividad-ver-agenda-05.png](./04-actividad-ver-agenda-05.png) |
+
+> Nota: Se corrigieron cierres de flujo en los diagramas `04-actividad-solicitar-turno-01.puml`, `04-actividad-registrar-llegada-03.puml`, `04-actividad-registrar-paciente-04.puml` y `04-actividad-ver-agenda-05.puml` (un único `stop` al final; `END` en flujos alternativos). Ver PR #98.

--- a/ia/a2/documentador-coordinador.md
+++ b/ia/a2/documentador-coordinador.md
@@ -229,7 +229,7 @@ Todos los comentarios generados por Copilot fueron revisados y considerados pert
 
 | Archivo | Cambio sugerido |
 |---|---|
-| `diagramas/02-casos-de-uso/02-caso-uso-cancelar-turno-02.puml` L6 | Agregar `Paciente -- UC1` (actor Paciente no está asociado al caso de uso) |
+| `diagramas/02-casos-de-uso/02-caso-uso-cancelar-turno-02.puml` L6 | Archivo eliminado en PR #87; referencia histórica mantenida en revisión. |
 | `diagramas/02-casos-de-uso/02-caso-uso-registrar-llegada-03.puml` L4–5 | Agregar `actor Paciente` y `Paciente -- UC1` (actor ausente; CU3 requiere Paciente, Secretaria y Doctor) |
 | `diagramas/02-casos-de-uso/02-caso-uso-registrar-llegada-03.puml` L8–10 | Vincular `UC4 "Ver lista de espera"` al flujo central con `<<extend>>`, o retirarlo a un diagrama propio |
 | `diagramas/02-casos-de-uso/02-caso-uso-registrar-paciente-04.puml` L12 | Eliminar `UC5 "Solicitar turno"` (usecase sin relación y comentario con RF incorrecto) |

--- a/ia/a2/modelador-diagramas-casos-uso.md
+++ b/ia/a2/modelador-diagramas-casos-uso.md
@@ -19,8 +19,7 @@ Asegúrate de incluir:
 *   **Ajustes manuales:** Se agregó el bloque `rectangle "Sistema de Turnos Médicos" { }` para delimitar el sistema. Se modificó manualmente la relación de notificación a `<<include>>` (`UC1 ..> UC4 : <<include>>`) ya que es una regla obligatoria del dominio.
 
 **2. 02-caso-uso-cancelar-turno-02.puml**
-*   **Output generado:** Identificó correctamente las inclusiones de búsqueda y liberación de turno, pero falló en la obligatoriedad de la notificación y omitió el límite del sistema.
-*   **Ajustes manuales:** Se envolvió el diagrama en el bloque `rectangle`. Se corrigió la relación "Notificar cancelación" cambiándola de `<<extend>>` a `<<include>>` para cumplir con las reglas del negocio.
+<!-- Nota: Este caso de uso fue eliminado en la feature mergeada PR #87. Las observaciones históricas se mantienen en el historial del repositorio, pero el archivo ya no existe en la rama principal. -->
 
 **3. 02-caso-uso-registrar-llegada-03.puml**
 *   **Output generado:** Omitió por completo al actor "Doctor" en el código PlantUML e intentó aislar el caso de uso "Ver lista de espera". Omitió el `rectangle`.

--- a/ia/a3/esp-actividades-3-4-5.md
+++ b/ia/a3/esp-actividades-3-4-5.md
@@ -7,7 +7,10 @@ Este documento registra la interacción con GitHub Copilot para la generación d
 ## Caso de Uso 3: Registrar llegada del paciente
 
 **Prompt utilizado:**
+**Prompt utilizado:**
+```
 Actúa como un Especialista en UML y Analista Funcional. Debo generar el diagrama de actividades para el Caso de Uso 3: "Registrar llegada del paciente", siguiendo la estructura de la Actividad Obligatoria N°3.
+```
 
 CONTEXTO DE ENTRADA (Referencia obligatoria):
 - Basate en el flujo lógico de: diagramas/03-escenarios-casos-de-uso/03-registrar-llegada-del-paciente-exitoso.md
@@ -23,11 +26,28 @@ REQUISITOS TÉCNICOS DE SALIDA:
 
 Genera el código PlantUML completo y profesional.
 
+### Archivos de contexto referenciados
+- `diagramas/02-casos-de-uso/` (casos de uso y actores)
+- `diagramas/03-escenarios-casos-de-uso/` (escenarios y pasos del flujo)
+
+### Ajustes al output de la IA
+- Sintaxis PlantUML: estandarización de `start`/`stop` y uso de `END` para cierres alternativos (RC1/RC4/RC5/RC6).
+- Estructura: verificación y ajuste de swimlanes (mínimo 3) y densidad de actividades (>=10).
+- Legibilidad: normalización de notas, rótulos y decisiones (rombos) para trazabilidad.
+
+### Iteraciones
+- v1: Prompt inicial — diagrama generado por IA con varios `stop` intermedios.
+- v2: Se solicitó explicitar swimlanes y decisiones; IA regeneró el diagrama.
+- v3: Ajustes manuales finales: reemplazo de `stop` intermedios por `END` y un único `stop` global.
+
 
 ## Caso de Uso 4: Registrar paciente
 
 **Prompt utilizado:**
+**Prompt utilizado:**
+```
 Actúa como un Especialista en UML y Analista Funcional. Debo generar el diagrama de actividades para el Caso de Uso 4: "Registrar paciente", siguiendo la estructura de la Actividad Obligatoria N°3 y continuando el trabajo de la PR #89.
+```
 
 CONTEXTO DE ENTRADA (Referencia obligatoria):
 - Basate en el flujo lógico de: diagramas/03-escenarios-casos-de-uso/03-registrar-paciente-exitoso.md
@@ -47,7 +67,10 @@ Genera el código PlantUML completo para integrar en la PR #89. Esta PR luego se
 ## Caso de Uso 5: Ver agenda
 
 **Prompt utilizado:**
+**Prompt utilizado:**
+```
 Actúa como un Especialista en UML y Analista Funcional Sr. Debo generar el diagrama de actividades para el Caso de Uso 5: "Ver agenda", siguiendo la estructura de la Actividad Obligatoria N°3 y consolidando el trabajo en la PR #89.
+```
 
 CONTEXTO DE ENTRADA (Referencia obligatoria):
 - Basate en el flujo lógico de: diagramas/03-escenarios-casos-de-uso/03-ver-agenda-exitoso.md
@@ -62,3 +85,29 @@ REQUISITOS TÉCNICOS DE SALIDA:
 6. Sintaxis: Utiliza la sintaxis moderna de PlantUML.
 
 Genera el código PlantUML completo para integrar en la PR #89. Esta PR luego se mergeará manualmente a la PR #88 para su review.
+
+### Archivos de contexto referenciados
+- `diagramas/02-casos-de-uso/`
+- `diagramas/03-escenarios-casos-de-uso/`
+
+### Ajustes al output de la IA
+- Incorporación de alternativas para agenda vacía y error de autenticación; normalización de cierres alternativos a `END`.
+- Verificación de rombos de decisión y densidad mínima de actividades.
+
+### Iteraciones
+- v1: Prompt inicial — salida sin manejo exhaustivo de errores.
+- v2: Se solicitó manejo de autenticación y agenda vacía; IA incorporó alternativas.
+- v3: Ajustes manuales finales: sustitución de `stop` intermedios por `END` y revisión de swimlanes.
+
+### Archivos de contexto referenciados
+- `diagramas/02-casos-de-uso/`
+- `diagramas/03-escenarios-casos-de-uso/`
+
+### Ajustes al output de la IA
+- Definición clara de comportamiento ante pacientes preexistentes (caso alternativo termina en `END`).
+- Completitud de actividades hasta alcanzar el mínimo de 10 nodos.
+
+### Iteraciones
+- v1: Prompt inicial — diagrama base generado.
+- v2: Se pidió manejo de duplicados y flujo alternativo; IA actualizó el diagrama.
+- v3: Ajustes manuales para estandarizar cierres alternativos y garantizar un único `stop` final.


### PR DESCRIPTION
Resumen:
Corrección de cierres de flujo en diagramas de actividades y documentación IA para cumplir las observaciones (RC1/RC4/RC5/RC6/RC8/RC9/RC10). Se normalizan los stop/END, se encierran los prompts en bloques de código y se actualiza el índice y el changelog.

Cambios relevantes:

Unificar fin de flujo: reemplazo de stop intermedios por END en flujos alternativos y dejar un único stop final.
Documentación IA: prompts encerrados en triple-backtick y añadidas secciones de contexto, ajustes e iteraciones.
Limpieza de referencias: eliminación/nota sobre el CU eliminado (PR #87) en índices y documentación.
Changelog: entrada de una línea referenciando PR #98.
Nota en índice de diagramas sobre las correcciones aplicadas.