### PR TITLE
Restaurar Caso de Uso 2 (Cancelar turno) y corregir modelado

### DIFF
--- a/diagramas/02-casos-de-uso/diagramas_de_casos_de_uso.md
+++ b/diagramas/02-casos-de-uso/diagramas_de_casos_de_uso.md
@@ -1,7 +1,7 @@
 # Diagramas de Casos de Uso
 
 - [Caso de Uso 1 - Solicitar turno](02-caso-uso-solicitar-turno-01/02-caso-uso-solicitar-turno-01.puml)
-<!-- Caso de Uso 2 - Cancelar turno: archivo eliminado en PR #87 -->
+- [Caso de Uso 2 - Cancelar turno](02-caso-uso-cancelar-turno-02/02-caso-uso-cancelar-turno-02.puml)
 - [Caso de Uso 3 - Registrar llegada del paciente](02-caso-uso-registrar-llegada-03/02-caso-uso-registrar-llegada-03.puml)
 - [Caso de Uso 4 - Registrar al paciente](02-caso-uso-registrar-paciente-04/02-caso-uso-registrar-paciente-04.puml)
 - [Caso de Uso 5 - Ver agenda](02-caso-uso-ver-agenda-05/02-caso-uso-ver-agenda-05.puml)

--- a/ia/a2/modelador-diagramas-casos-uso.md
+++ b/ia/a2/modelador-diagramas-casos-uso.md
@@ -19,7 +19,9 @@ Asegúrate de incluir:
 *   **Ajustes manuales:** Se agregó el bloque `rectangle "Sistema de Turnos Médicos" { }` para delimitar el sistema. Se modificó manualmente la relación de notificación a `<<include>>` (`UC1 ..> UC4 : <<include>>`) ya que es una regla obligatoria del dominio.
 
 **2. 02-caso-uso-cancelar-turno-02.puml**
-<!-- Nota: Este caso de uso fue eliminado en la feature mergeada PR #87. Las observaciones históricas se mantienen en el historial del repositorio, pero el archivo ya no existe en la rama principal. -->
+*   **Output generado:** Identificó correctamente las inclusiones de búsqueda y liberación de turno, pero modeló inicialmente la notificación como `<<extend>>`.
+*   **Ajustes manuales:** Se envolvió el diagrama en el bloque `rectangle "Sistema de Turnos Médicos" { }`. Se corrigió la relación "Notificar cancelación" cambiándola de `<<extend>>` a `<<include>>` para cumplir con las reglas del negocio. Se mantuvo al actor `Paciente` y se agregó la asociación con `Secretaria` para mostrar los roles que pueden cancelar turnos.
+*   **Justificación:** El Caso de Uso 2 es fundamental para la consistencia del modelado y el diseño del sistema; su eliminación dejaba incompletos los diagramas y los requisitos de negocio. Se restauró y documentó la trazabilidad relativa a la PR #87 para que el equipo entienda la decisión.
 
 **3. 02-caso-uso-registrar-llegada-03.puml**
 *   **Output generado:** Omitió por completo al actor "Doctor" en el código PlantUML e intentó aislar el caso de uso "Ver lista de espera". Omitió el `rectangle`.


### PR DESCRIPTION
Se restauró el Caso de Uso 2 — "Cancelar turno" — que había sido eliminado en la PR #87, porque su ausencia generaba inconsistencias en los diagramas y en la trazabilidad del diseño. El diagrama asociado fue corregido: se envolvió en rectangle "Sistema de Turnos Médicos" { } y la relación "Notificar cancelación" se cambió de <<extend>> a <<include>> (es una acción obligatoria del flujo). La restauración y las correcciones están documentadas en la PR #100 para auditoría y contexto del equipo.