### PR TITLE
fix: apply RC18, RC19, RCN1, RC20 requested changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 - **Grupo:** Grupo N° 1.
 
 ## Introducción
-Este proyecto tiene el objetivo de desarrollar el diseño orientado a objetos de un sistema de turnos médicos.
 - [Introducción detallada del proyecto](./anexos/introduccion.md)
 
 ## Integrantes
@@ -17,26 +16,17 @@ Este proyecto tiene el objetivo de desarrollar el diseño orientado a objetos de
 | Valeria Silva | 156612 | @ValeriaMSilva | Especialista en Secuencia |
 | Carola Benvenuto | 158686 | @carolabenvenuto-uces | Documentador y Coordinador |
 
-## 📊 Modelo Dinámico del Sistema (Actividad N3)
+## Diagramas UML
 
-En este tercer entregable, el equipo profundiza en el comportamiento dinámico y operativo del sistema mediante el diseño de los modelos que describen:
+* [Diagramas de Casos de Uso](./diagramas/02-casos-de-uso/diagramas_de_casos_de_uso.md)
+* [Escenarios de Casos de Uso](./diagramas/03-escenarios-casos-de-uso/escenarios_de_casos_de_uso.md)
+* [Diagramas de Actividades](./diagramas/04-diagramas-actividades/diagramas_de_actividades.md)
+* [Diagramas de Secuencia](./diagramas/05-diagramas-secuencia/diagramas_de_secuencias.md)
 
-- los flujos de trabajo generales de cada caso de uso,
-- las responsabilidades de los actores y del sistema, y
-- la interacción temporal entre objetos y mensajes.
+## Documentación Adicional
 
-* [Índice de Diagramas de Actividades](./diagramas/04-diagramas-actividades/diagramas_de_actividades.md) — Modelado y lógica de negocio para los 5 Casos de Uso del sistema, representando los flujos principales y alternativos con carriles (*swimlanes*) claros.
-* [Índice de Diagramas de Secuencia](./diagramas/05-diagramas-secuencia/diagramas_de_secuencias.md) — Interacción temporal, firmas de mensajes en `camelCase` y ciclos de vida de los objetos en los 5 escenarios.
-
-## 🏛️ Historial de Diseño y Fundamentos (A2 y Parcial)
-
-- [Diagramas de Casos de Uso](./diagramas/02-casos-de-uso/diagramas_de_casos_de_uso.md) — Definición del alcance y actores del sistema.
-- [Escenarios de Casos de Uso](./diagramas/03-escenarios-casos-de-uso/escenarios_de_casos_de_uso.md) — Flujos principales, alternativos y excepciones de cada caso de uso.
 - [Principios SOLID](./anexos/principios-solid/principios_solid.md)
 - [Tarjetas CRC](./herramientas-agile/tarjetas-crc/tarjetas_crc.md)
-- [Diagramas de Clases (diagramasUML.md)](./diagramas/diagramasUML.md) — Modelo estático que apoya la interpretación de los procesos dinámicos.
-
-## ⚙️ Gestión y Procesos
-- [Historial de Procesos IA (A2, Parcial y A3)](./ia/)
+- [Historial de Procesos IA](./ia/)
 - [Herramientas Agile](./herramientas-agile/herramientas_agile.md)
-- [Historial de Cambios (Changelog)](./changelog.md)
+- [Historial de Cambios](./changelog.md)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## [Release Actividad N3] - 2026-05-21
 
 ### Added
@@ -16,6 +18,7 @@
 - [fix/correccion-indices-readme-coordinador] Corrección de formato del índice de diagramas de actividades, reestructuración del `README.md` para asegurar coherencia conceptual del modelo dinámico y actualización de `diagramas/diagramasUML.md` con la complementariedad de modelos. PR: [#95](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/95) - @carolabenvenuto-uces (Documentador y Coordinador) 
 - [fix/correccion-puml-caso-de-uso] correccion de la sintaxis de puml y restauración de actividad 2 caso de uso. PR: [#97](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/97) - @caterinacerdan (Especialista en diagramas de actividades caso de uso 1 y 2)
 - [fix/esp-actividades-3-4-5-doc-ia] Corrección de cierres de flujo en diagramas de actividades (un único `stop`; `END` en alternativos) y actualización de documentación IA. PR: [#98](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/98) - @FacundoGuiraldes (Especialista en Diagramas de Actividades)
+- [fix/rc-1-18-19-20] Corrección adicional de los Diagramas de Actividades para los Casos de Uso 3, 4 y 5. PR: [#101](https://github.com/FacundoGuiraldes/SistemaTurnosMedicos/pull/101) - @FacundoGuiraldes (Especialista en Diagramas de Actividades - Casos de Uso 3, 4 y 5)
 
 ## [Release Primer Parcial] - 2026-04-25
 ### Added

--- a/diagramas/04-diagramas-actividades/diagramas_de_actividades.md
+++ b/diagramas/04-diagramas-actividades/diagramas_de_actividades.md
@@ -1,11 +1,7 @@
 # Diagramas de Actividades
 
-| Caso de Uso | Código fuente | Vista previa |
-|---|---|---|
-| Solicitar Turno | [04-actividad-solicitar-turno-01.puml](./04-actividad-solicitar-turno-01.puml) | [04-actividad-solicitar-turno-01.png](./04-actividad-solicitar-turno-01.png) |
-| Cancelar Turno | [04-actividad-cancelar-turno-02.puml](./04-actividad-cancelar-turno-02.puml) | [04-actividad-cancelar-turno-02.png](./04-actividad-cancelar-turno-02.png) |
-| Registrar Llegada del Paciente | [04-actividad-registrar-llegada-03.puml](./04-actividad-registrar-llegada-03.puml) | [04-actividad-registrar-llegada-03.png](./04-actividad-registrar-llegada-03.png) |
-| Registrar Paciente | [04-actividad-registrar-paciente-04.puml](./04-actividad-registrar-paciente-04.puml) | [04-actividad-registrar-paciente-04.png](./04-actividad-registrar-paciente-04.png) |
-| Ver Agenda | [04-actividad-ver-agenda-05.puml](./04-actividad-ver-agenda-05.puml) | [04-actividad-ver-agenda-05.png](./04-actividad-ver-agenda-05.png) |
-
-> Nota: Se corrigieron cierres de flujo en los diagramas `04-actividad-solicitar-turno-01.puml`, `04-actividad-registrar-llegada-03.puml`, `04-actividad-registrar-paciente-04.puml` y `04-actividad-ver-agenda-05.puml` (un único `stop` al final; `END` en flujos alternativos). Ver PR #98.
+* [Diagrama de Actividad - Solicitar Turno](./04-actividad-solicitar-turno-01.puml)
+* [Diagrama de Actividad - Cancelar Turno](./04-actividad-cancelar-turno-02.puml)
+* [Diagrama de Actividad - Registrar Llegada del Paciente](./04-actividad-registrar-llegada-03.puml)
+* [Diagrama de Actividad - Registrar Paciente](./04-actividad-registrar-paciente-04.puml)
+* [Diagrama de Actividad - Ver Agenda](./04-actividad-ver-agenda-05.puml)

--- a/diagramas/diagramasUML.md
+++ b/diagramas/diagramasUML.md
@@ -1,25 +1,6 @@
 # Diagramas UML
 
-Este espacio centraliza los modelos gráficos y especificaciones que describen la estructura y el comportamiento dinámico de nuestro **Sistema de Turnos Médicos**.
-
-## 🏛️ Modelo Estático y Requerimientos (Entregas Anteriores)
-- [Diagrama de Clases](01-diagrama-clases/diagrama_clases.md) — Representación de la estructura del sistema, sus clases, atributos, métodos y relaciones fundamentales.
-- [Diagramas de Casos de Uso](02-casos-de-uso/diagramas_de_casos_de_uso.md) — Definición del alcance del sistema y las interacciones entre los actores y las funcionalidades principales.
-- [Escenarios de Casos de Uso](03-escenarios-casos-de-uso/escenarios_de_casos_de_uso.md) — Documentación detallada de los flujos principales, alternativos y excepciones de cada caso de uso.
-
-## 📊 Modelo Dinámico y Operativo (Actividad N°3)
-- [Diagramas de Actividades](04-diagramas-actividades/diagramas_de_actividades.md) — Modelado del flujo de trabajo y la lógica de negocio de los 5 Casos de Uso, distribuyendo actividades mediante carriles (*swimlanes*) para delimitar responsabilidades claras.
-- [Diagramas de Secuencia](05-diagramas-secuencia/diagramas_de_secuencias.md) — Representación de la interacción temporal y cronológica entre los objetos del sistema, detallando el intercambio de mensajes en formato `camelCase` y el control del ciclo de vida de los componentes.
-
-## 📌 Complementariedad entre Modelos
-
-Los nuevos diagramas de la Actividad N°3 refuerzan el análisis del sistema al sumar la visión dinámica a la base estática ya representada.
-
-- El **Diagrama de Clases** describe la estructura estática del sistema: clases, atributos, métodos y relaciones.
-- Los **Diagramas de Actividades** modelan los flujos de trabajo, decisiones y responsabilidades por carriles (*swimlanes*) para los 5 Casos de Uso, mostrando cómo se ejecuta la lógica de negocio en cada proceso.
-- Los **Diagramas de Secuencia** representan la interacción temporal entre los objetos y las llamadas de mensaje en cada escenario, evidenciando el orden y el ciclo de vida de los componentes.
-
-Juntos, estos artefactos:
-- conectan el comportamiento operativo con la arquitectura del sistema,
-- permiten verificar que el diseño de clases soporta los procesos reales,
-- y garantizan coherencia entre el modelo estático y el modelo dinámico del Sistema de Turnos Médicos.
+* [Diagramas de Casos de Uso](./02-casos-de-uso/diagramas_de_casos_de_uso.md)
+* [Escenarios de Casos de Uso](./03-escenarios-casos-de-uso/escenarios_de_casos_de_uso.md)
+* [Diagramas de Actividades](./04-diagramas-actividades/diagramas_de_actividades.md)
+* [Diagramas de Secuencia](./05-diagramas-secuencia/diagramas_de_secuencias.md)


### PR DESCRIPTION
## Resumen
Se aplicaron las correcciones solicitadas por revisión para la actividad N3, ajustando índices y documentación a los formatos de entrega requeridos.

### Cambios incluidos
- README.md
  - Eliminado texto de relleno innecesario.
  - Conservado formato de entrega original con la sección de roles mínima y clara.

- diagramas_de_actividades.md
  - Ajustado el índice al formato estricto requerido por RC19.
  - Título y lista de enlaces a los 5 diagramas de actividades correctamente normalizados.

- diagramasUML.md
  - Reemplazado contenido extra por un índice simple de navegación.
  - Cumple RCN1 con solo los enlaces de los tipos de diagramas.

- changelog.md
  - Verificado que `## Unreleased` queda en la parte superior del archivo.
  - Cumple RC20 para futuras integraciones en `develop`.