### PR TITLE
fix: incrustar imagen del diagrama Facade en anexo estructural (RC1)

### DIFF
--- a/anexos/patrones-diseno/patron-de-diseno-estructural.md
+++ b/anexos/patrones-diseno/patron-de-diseno-estructural.md
@@ -52,7 +52,7 @@ El diagrama se organiza en tres paquetes principales:
 
 Esta organización permite leer el diagrama aun sin renderizar la imagen: los clientes dependen de una única entrada visible, la fachada centraliza la coordinación y los subsistemas quedan ubicados detrás de esa interfaz simplificada.
 
-[Estructura de clases con diagrama UML](../../diagramas/01-diagrama-clases/01-patron-estructural-facade.png)
+![Diagrama de clases - Patrón Facade](../../diagramas/01-diagrama-clases/01-patron-estructural-facade.png)
 
 ## Justificación Técnica de la Estructura de Clases
 
@@ -116,4 +116,3 @@ Por ejemplo, al cancelar un turno, el cliente invoca `cancelarTurno` sobre `Sist
 - Mantiene las reglas de negocio distribuidas en clases del dominio.
 - Facilita incorporar cambios internos sin alterar la forma en que los clientes usan el sistema.
 - Hace más claro el diagrama de clases al separar clientes, fachada y subsistemas.
-


### PR DESCRIPTION
## 🔧 Fix RC1 — Incrustar imagen del diagrama Facade en el anexo

### Corrección aplicada
El docente observó que el diagrama de clases del patrón Facade no estaba incrustado 
para previsualizarse en el anexo, sino que aparecía como un enlace clickeable.

### Cambio realizado
En `anexos/patrones-diseno/patron-de-diseno-estructural.md`, se reemplazó:

```markdown
[Estructura de clases con diagrama UML](../../diagramas/01-diagrama-clases/01-patron-estructural-facade.png)
```

por:

```markdown
![Diagrama de clases - Patrón Facade](../../diagramas/01-diagrama-clases/01-patron-estructural-facade.png)
```

### Archivo modificado
- `anexos/patrones-diseno/patron-de-diseno-estructural.md`

### Vinculación
- Resuelve RC1 del code review del docente @MVelasquez98 en PR #144