### PR TITLE
fix: agregar LSP e ISP en sección SOLID del anexo Observer (RC2)

### DIFF
--- a/anexos/patrones-diseno/patron-de-diseno-de-comportamiento.md
+++ b/anexos/patrones-diseno/patron-de-diseno-de-comportamiento.md
@@ -5,6 +5,8 @@ Los patrones de diseño de comportamiento se centran en la comunicación y colab
 
 - Responsabilidad Única (SRP): Cada objeto tiene una única razón para cambiar; por ejemplo, un notificador se encarga sólo de notificar.
 - Abierto/Cerrado (OCP): Los componentes pueden extenderse (añadiendo nuevos observadores) sin modificar la lógica del sujeto que publica eventos.
+- Sustitución de Liskov (LSP): Los observadores concretos (`NotificadorPaciente`, `NotificadorMedico`, `SistemaFacturacion`) son sustitutos válidos de `IObserverTurno`; el sujeto puede usar cualquiera sin distinción.
+- Segregación de Interfaces (ISP): `IObserverTurno` e `ISubjectTurno` son interfaces pequeñas y enfocadas; ningún cliente está obligado a implementar métodos que no necesita.
 - Inversión de Dependencias (DIP): `TurnoMedico` depende de la abstracción `IObserverTurno` y no de sus implementaciones concretas, permitiendo sustituir o ampliar observadores sin recompilar el sujeto.
 
 ## Propósito y Tipo del Patrón


### PR DESCRIPTION
## 🔧 Fix RC2 — Agregar LSP e ISP en sección SOLID del anexo Observer

### Corrección aplicada
El docente observó que la introducción de patrones de comportamiento y su relación 
con SOLID abordaba solo tres de los cinco principios (SRP, OCP, DIP), omitiendo 
LSP e ISP.

### Cambio realizado
En `anexos/patrones-diseno/patron-de-diseno-de-comportamiento.md`, se agregaron 
los dos principios faltantes en la sección SOLID:

- **LSP:** Los observadores concretos (`NotificadorPaciente`, `NotificadorMedico`, 
  `SistemaFacturacion`) son sustitutos válidos de `IObserverTurno`; el sujeto puede 
  usar cualquiera sin distinción.
- **ISP:** `IObserverTurno` e `ISubjectTurno` son interfaces pequeñas y enfocadas; 
  ningún cliente está obligado a implementar métodos que no necesita.

### Archivo modificado
- `anexos/patrones-diseno/patron-de-diseno-de-comportamiento.md`

### Vinculación
- Resuelve RC2 del code review del docente @MVelasquez98 en PR #144